### PR TITLE
Force the hostname to match the config value.

### DIFF
--- a/verify-hostname.sh
+++ b/verify-hostname.sh
@@ -1,0 +1,7 @@
+if [ -e /etc/hostname-should-verify ]
+then
+  grep "^<%= @attributes.hostname %>$" /etc/hostname || exit 1
+else
+  echo 'hostname has not been set by us; allowing access this once'
+  touch /etc/hostname-should-verify
+fi


### PR DESCRIPTION
Will work on first run, then the hostname must match or the script dies.

Include this recipe at the top of `install.sh`, right after:

```
source recipes/sunzi.sh
```