### PR TITLE
Add pagerduty recipe

### DIFF
--- a/pagerduty.sh
+++ b/pagerduty.sh
@@ -1,0 +1,7 @@
+if aptitude search '~i ^pdagent$' | grep -q pdagent; then
+  echo "pdagent already installed, skipping."
+else
+  wget -O - http://packages.pagerduty.com/GPG-KEY-pagerduty | sudo apt-key add -
+  apt-get update
+  apt-get -y install pdagent pdagent-integrations
+fi


### PR DESCRIPTION
Installs pdagent so that we can trigger incidents from the command line.