### PR TITLE
Add repmgr logrotate recipe

### DIFF
--- a/logrotate-repmgr.sh
+++ b/logrotate-repmgr.sh
@@ -1,0 +1,4 @@
+# Configures logrotate for repmgr
+
+mv files/logrotate/repmgr /etc/logrotate.d/repmgr
+chown root:root /etc/logrotate.d/repmgr


### PR DESCRIPTION
Assumes you're using remote files *or* defining a local config file in `files/logrotate/files`. The default remote file for Platform can be [found here](https://github.com/metabahn/sunzi-files/blob/master/logrotate/repmgr).

Note that I changed the naming convention to `logrotate-{service}` so that it's easier to find. If it's cool with you all, I'll update the other logrotate recipes to match. I realize this is probably preference, so if you feel strongly the other way that's fine; not a huge deal to me.