### PR TITLE
Support multiple users when uploading public keys

### DIFF
--- a/keys.sh
+++ b/keys.sh
@@ -1,24 +1,35 @@
+# Installs public keys for multiple users.
+#
+# Required Attributes:
+#
+# - public_keys [Array<Hash>] list of users, with user directory and keys
+#     e.g.
+#     public_keys:
+#       {user}:
+#         user_dir: {user_dir}
+#         keys:
+#           - {key}
+
 if aptitude search '~i ^jq$' | grep -q jq; then
   echo "jq already installed, skipping."
 else
   sudo apt-get install -y jq
 fi
 
-if [ ! -d "/root/.ssh" ]; then
-  echo "Creating ssh directory for root"
-  mkdir /root/.ssh
-  touch /root/.ssh/authorized_keys
-fi
+<% if @attributes.keys %>
+echo "DEPRECATION: public_keys attribute should now be used in place of keys"
+<% end %>
 
-keys=$(jq .[] attributes/keys)
+<% @attributes.public_keys.each do |user, info| %>
+  if [ ! -d "<%= info['user_dir'] %>/.ssh" ]; then
+    echo "Creating ssh directory for <%= user %>"
+    mkdir <%= info['user_dir'] %>/.ssh
+    touch <%= info['user_dir'] %>/.ssh/authorized_keys
+    chown -r <%= user %> <%= info['user_dir'] %>/.ssh
+  fi
 
-SAVEIFS=$IFS
-IFS=$(echo -en "\n\b")
-for key in ${keys[@]}; do
-  key="${key%\"}"
-  key="${key#\"}"
-  echo $key
-  echo '-'
-  grep -q -F "$key" /root/.ssh/authorized_keys || echo $key >> /root/.ssh/authorized_keys
-done
-IFS=$SAVEIFS
+  <% info['keys'].each do |key| %>
+    echo "Uploading key for <%= user %>"
+    grep -q -F "<%= key %>" <%= info['user_dir'] %>/.ssh/authorized_keys || echo <%= key %> >> <%= info['user_dir'] %>/.ssh/authorized_keys
+  <% end %>
+<% end %>


### PR DESCRIPTION
Exactly what it says. Includes a deprecation message if it finds the old `keys` attribute.

I needed this to install public keys for the `root` and `postgres` user on the postgres nodes.