### PR TITLE
Add copytruncate to the logrotate options

### DIFF
--- a/apps-logrotate.sh
+++ b/apps-logrotate.sh
@@ -11,6 +11,7 @@ cat >/etc/logrotate.d/apps-logrotate <<EOL
   compress
   delaycompress
   sharedscripts
+  copytruncate
   postrotate
     /usr/bin/passenger-config restart-app / > /dev/null
   endscript


### PR DESCRIPTION
More general solution to the issue caused by creating a new logfile.

See: https://github.com/papertrail/remote_syslog2#log-rotation